### PR TITLE
Key location via "Sources"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Changelog
 
 ## [Unreleased]
+* [#4](https://github.com/Blackjacx/ASCKit/pull/4): Key location via "Sources" - [@blackjacx](https://github.com/blackjacx).

--- a/Package.resolved
+++ b/Package.resolved
@@ -63,6 +63,15 @@
           "revision": "8f4bfa5bc1951440c15710e9e893721aa4b2765c",
           "version": "1.1.3"
         }
+      },
+      {
+        "package": "SwiftKeychainWrapper",
+        "repositoryURL": "https://github.com/jrendel/SwiftKeychainWrapper",
+        "state": {
+          "branch": null,
+          "revision": "185a3165346a03767101c4f62e9a545a0fe0530f",
+          "version": "4.0.1"
+        }
       }
     ]
   },

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/vapor/jwt-kit.git",
         "state": {
           "branch": null,
-          "revision": "6055fe8439769aa3646a3c797d573ce7305849c8",
-          "version": "4.2.0"
+          "revision": "b50b30b567726b14ac282aa6d3a42a52c1ebc8c0",
+          "version": "4.2.2"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "8f4bfa5bc1951440c15710e9e893721aa4b2765c",
-          "version": "1.1.3"
+          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
+          "version": "1.1.6"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,14 +13,15 @@ let package = Package(
         .library(name: "ASCKit", targets: ["ASCKit"]),
     ],
     dependencies: [
-       .package(name: "Engine", url: "https://github.com/blackjacx/engine", .branch("develop")),
+        .package(name: "Engine", url: "https://github.com/blackjacx/engine", .branch("develop")),
         // .package(name: "Engine", path: "../Engine"),
+        .package(name: "SwiftKeychainWrapper", url: "https://github.com/jrendel/SwiftKeychainWrapper", from: "4.0.1"),
         .package(name: "Quick", url: "https://github.com/Quick/Quick", from: "3.1.2"),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble", from: "9.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.1.0"),
     ],
     targets: [
-        .target(name: "ASCKit", dependencies: [.product(name: "JWTKit", package: "jwt-kit"), "Engine",]),
+        .target(name: "ASCKit", dependencies: [.product(name: "JWTKit", package: "jwt-kit"), "Engine", "SwiftKeychainWrapper"]),
         .testTarget(name: "ASCKitTests", dependencies: ["ASCKit", "Quick", "Nimble"]),
     ]
 )

--- a/Sources/ASCKit/ASCKit.swift
+++ b/Sources/ASCKit/ASCKit.swift
@@ -7,3 +7,8 @@
 
 import Foundation
 
+public struct ASCKit {
+
+    /// Global keychain for all ASC related topics
+    public static var keychain = Keychain()
+}

--- a/Sources/ASCKit/JSONWebToken.swift
+++ b/Sources/ASCKit/JSONWebToken.swift
@@ -10,7 +10,7 @@ import JWTKit
 
 public struct JSONWebToken {
 
-    public static func create(keyFile: String, kid: String, iss: String) throws -> String {
+    public static func create(privateKeySource: PrivateKeySource, kid: String, iss: String) throws -> String {
 
         let claims = JWTClaims(iss: iss,
                                exp: Date(timeIntervalSinceNow: 20 * 60),
@@ -18,9 +18,24 @@ public struct JSONWebToken {
                                alg: "ES256")
 
         let signers = JWTSigners()
+        let keyData: Data
 
-        guard let keyData = FileManager.default.contents(atPath: keyFile) else {
-            throw Error.fileNotFound(keyFile)
+        switch privateKeySource {
+        case .localFilePath(let path):
+            guard let data = FileManager.default.contents(atPath: path) else {
+                throw Error.fileNotFound(path)
+            }
+            keyData = data
+        case .keychain(let keychainKey):
+            guard let data = ASCKit.keychain.keychainItem(for: keychainKey)?.data(using: .utf8) else {
+                throw Error.keychainItemNotFound(keychainKey)
+            }
+            keyData = data
+        case .inline(let privateKey):
+            guard let data = privateKey.data(using: .utf8) else {
+                throw Error.conversionFailed
+            }
+            keyData = data
         }
 
         try signers.use(.es256(key: .private(pem: keyData)))
@@ -30,11 +45,67 @@ public struct JSONWebToken {
     }
 }
 
+public extension JSONWebToken {
+
+    enum PrivateKeySource: Equatable, Hashable {
+        case localFilePath(path: String)
+        case keychain(keychainKey: String)
+        case inline(privateKey: String)
+    }
+}
+
+extension JSONWebToken.PrivateKeySource: Codable {
+
+    enum CodingKeys: CodingKey {
+        case localFilePath, keychain, inline
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .localFilePath(let path):
+            try container.encode(path, forKey: .localFilePath)
+        case .keychain(let keychainKey):
+            try container.encode(keychainKey, forKey: .keychain)
+        case .inline(let privateKey):
+            try container.encode(privateKey, forKey: .inline)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let key = container.allKeys.first
+
+        switch key {
+        case .localFilePath:
+            let path = try container.decode(String.self, forKey: .localFilePath)
+            self = .localFilePath(path: path)
+        case .keychain:
+            let keychainKey = try container.decode(String.self, forKey: .keychain)
+            self = .keychain(keychainKey: keychainKey)
+        case .inline:
+            let privateKey = try container.decode(String.self, forKey: .inline)
+            self = .inline(privateKey: privateKey)
+        default:
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "Unabled to decode enum."
+                )
+            )
+        }
+    }
+}
+
 private extension JSONWebToken {
 
     enum Error: Swift.Error {
         case credentialsNotSet
         case unableToConstructJWT
+        case keychainItemNotFound(String)
+        case conversionFailed
         case fileNotFound(String)
         case privateKeyInvalid
         case privateKeyEmpty

--- a/Sources/ASCKit/Keychain.swift
+++ b/Sources/ASCKit/Keychain.swift
@@ -1,0 +1,69 @@
+//
+//  Keychain.swift
+//  ASCKit
+//
+//  Created by Stefan Herold on 04.04.21.
+//
+
+import Foundation
+import SwiftKeychainWrapper
+import Engine
+
+public struct Keychain {
+
+    private let keychain = KeychainWrapper(serviceName: ProcessInfo.processId)
+    private let persistentStore = UserDefaults.standard
+
+    /// The private store properties for our keychain items to not pull them
+    /// from the keychain if the app is still in memory. This allows us to
+    /// bypass the locked keychain when iPhone is locked and the app is just in
+    /// background.
+    private var transientStore: [String: String] = [:]
+
+    // MARK: - Public Interface
+
+    public mutating func setKeychainItem(_ value: String, key: String) -> Bool {
+
+        // Make sure to always set a Data object to the Keychain since
+        // otherwise storing an item will give you unexpected behaviour.
+        keychain.set(value, forKey: key)
+
+        guard keychain.string(forKey: key) == value else {
+            return false
+        }
+        transientStore[key] = value
+        persistentStore.set(true, forKey: key)
+
+        return true
+    }
+
+    public mutating func keychainItem(for key: String) -> String? {
+
+        let hasKeychainItem = persistentStore.bool(forKey: key)
+
+        guard hasKeychainItem else {
+            removeKeychainItem(for: key)
+            return nil
+        }
+
+        if let item = transientStore[key] {
+            return item
+        }
+
+        guard let value = keychain.string(forKey: key) else {
+            removeKeychainItem(for: key)
+            return nil
+        }
+
+        transientStore[key] = value
+        return value
+    }
+
+    public mutating func removeKeychainItem(for key: String) {
+
+        transientStore[key] = nil
+        persistentStore.setValue(nil, forKey: key)
+        keychain.removeObject(forKey: key)
+    }
+}
+

--- a/Sources/ASCKit/models/ApiKey.swift
+++ b/Sources/ASCKit/models/ApiKey.swift
@@ -10,14 +10,14 @@ import Foundation
 public struct ApiKey: IdentifiableModel {
     public var id: String
     public var name: String
-    public var path: String
+    public var source: JSONWebToken.PrivateKeySource
     public var issuerId: String
     public var isActive: Bool
 
-    public init(id: String, name: String, path: String, issuerId: String, isActive: Bool = false) {
+    public init(id: String, name: String, source: JSONWebToken.PrivateKeySource, issuerId: String, isActive: Bool = false) {
         self.id = id
         self.name = name
-        self.path = path
+        self.source = source
         self.issuerId = issuerId
         self.isActive = isActive
     }

--- a/Sources/ASCKit/service/ApiKeysOperation.swift
+++ b/Sources/ASCKit/service/ApiKeysOperation.swift
@@ -110,6 +110,6 @@ public final class ApiKeysOperation: AsyncResultOperation<[ApiKey], Swift.Error>
         } else {
             throw AscError.noApiKeysRegistered
         }
-        return try JSONWebToken.create(keyFile: key.path, kid: key.id, iss: key.issuerId)
+        return try JSONWebToken.create(privateKeySource: key.source, kid: key.id, iss: key.issuerId)
     }
 }


### PR DESCRIPTION
## Before 
The key location was specified via file path only.

## Now
The key's location is now specified using a Source which is an enum that has the cases: `localFilePath`, `keychain`, `inline`. This provides much more flexibility when specifying where keys can be obtained from and is needed to put keys in the keychain in an app context.