### PR TITLE
Paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
 
 ## [Unreleased]
+* [#5](https://github.com/Blackjacx/ASCKit/pull/5): Paging - [@blackjacx](https://github.com/blackjacx).
 * [#4](https://github.com/Blackjacx/ASCKit/pull/4): Key location via "Sources" - [@blackjacx](https://github.com/blackjacx).

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/blackjacx/engine",
         "state": {
           "branch": "develop",
-          "revision": "2b5227197796764eb379407dde5d26706cfa2138",
+          "revision": "f189acecf7cafd0dec89a1d8fbe6eecfd4669719",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/blackjacx/engine",
         "state": {
           "branch": "develop",
-          "revision": "eda3fc3ee837b7879a68d40abdfdd8b39cd099fe",
+          "revision": "2b5227197796764eb379407dde5d26706cfa2138",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Engine", url: "https://github.com/blackjacx/engine", .branch("develop")),
-        // .package(name: "Engine", path: "../Engine"),
+//         .package(name: "Engine", path: "../Engine"),
         .package(name: "SwiftKeychainWrapper", url: "https://github.com/jrendel/SwiftKeychainWrapper", from: "4.0.1"),
         .package(name: "Quick", url: "https://github.com/Quick/Quick", from: "3.1.2"),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble", from: "9.0.0"),

--- a/Sources/ASCKit/ASCService.swift
+++ b/Sources/ASCKit/ASCService.swift
@@ -114,6 +114,13 @@ public struct ASCService {
 
     // MARK: - DEPRECATED
 
+    #warning("""
+        Don't forget to re-write AscGenericEndpoint.jsonDecode(...) when using operations for all calls above. We don't
+        use AscGenericEndpoint.list then directly anymore (like below) - just via the ListOperation so we can be sure
+        to get a PageableModel result then.
+    """)
+
+
     /// This will be transformed to a dependent operation once beta testers is realized as operation too
     static func listBetaGroups(filters: [Filter] = []) throws -> [BetaGroup] {
         let endpoint = AscGenericEndpoint.list(type: BetaGroup.self, filters: filters, limit: nil)

--- a/Sources/ASCKit/AscEndpoint.swift
+++ b/Sources/ASCKit/AscEndpoint.swift
@@ -129,12 +129,12 @@ extension AscGenericEndpoint: Endpoint {
 
 extension AscEndpoint: Endpoint {
 
+    var url: URL? {
+        nil
+    }
+
     /// Used o specify the id of an already registered key to use
     public static var apiKeyId: String?
-
-    var url: URL? {
-        return nil
-    }
 
     var host: String {
         baseUrlPath

--- a/Sources/ASCKit/Constants.swift
+++ b/Sources/ASCKit/Constants.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 public enum Constants {
+    public static let defaultPageSize: UInt = 50
     public static let maxPageSize: UInt = 200
 }

--- a/Sources/ASCKit/Constants.swift
+++ b/Sources/ASCKit/Constants.swift
@@ -11,3 +11,12 @@ public enum Constants {
     public static let defaultPageSize: UInt = 50
     public static let maxPageSize: UInt = 200
 }
+
+#if canImport(UIKit)
+import UIKit
+
+extension Constants {
+    public static let buttonSize: CGFloat = 44
+    public static let raster: CGFloat = 12
+}
+#endif

--- a/Sources/ASCKit/Model.swift
+++ b/Sources/ASCKit/Model.swift
@@ -10,6 +10,15 @@ import Foundation
 public protocol Model: Codable, Hashable {
 }
 
+public protocol Pageable: Model {
+    associatedtype ModelType: Model
+
+    var data: [ModelType] { get }
+    var totalCount: Int { get }
+    var limit: Int { get }
+    var nextUrl: URL? { get }
+}
+
 public protocol IdentifiableModel: Model, Identifiable {
     var id: String { get }
     var name: String { get }

--- a/Sources/ASCKit/models/PageableModel.swift
+++ b/Sources/ASCKit/models/PageableModel.swift
@@ -1,0 +1,49 @@
+//
+//  PageableModel.swift
+//  ASCKit
+//
+//  Created by Stefan Herold on 11.02.21.
+//
+
+import Foundation
+
+public struct PageableModel<M: Model>: Pageable {
+
+    public typealias ModelType = M
+    public var data: [ModelType]
+
+    public var totalCount: Int { meta.paging.total }
+    public var limit: Int { meta.paging.limit }
+    public var nextUrl: URL? { links.next }
+
+    var meta: PagingInformation
+    var links: PagedDocumentLinks
+
+    public init(data: [PageableModel<M>.ModelType] = []) {
+        self.data = data
+        self.meta = PagingInformation(paging: .init(total: 0, limit: 0))
+        self.links = PagedDocumentLinks(self: URL(string: "")!, next: URL(string: "")!)
+    }
+}
+
+public struct PagedDocumentLinks: Model {
+    /// (Required) The link that produced the current document.
+    var `self`: URL
+    /// The link to the next page of documents (nil for the last page)
+    var next: URL?
+    /// The link to the first page (always nil except for the last page)
+    var first: URL?
+}
+
+struct PagingInformation: Model {
+
+    struct Paging: Model {
+        /// (Required) The total number of resources matching your request.
+        var total: Int
+        /// (Required) The maximum number of resources to return per page, from 0 to 200.
+        var limit: Int
+    }
+
+    /// The paging information details.
+    var paging: Paging
+}

--- a/Sources/ASCKit/service/ASCService.swift
+++ b/Sources/ASCKit/service/ASCService.swift
@@ -19,7 +19,7 @@ public struct ASCService {
     /// result or fetches the first page if nil.
     public static func list<P: Pageable>(previousPageable: P?,
                                          filters: [Filter] = [],
-                                         limit: UInt? = nil) -> AnyPublisher<P, Network.Error> {
+                                         limit: UInt? = nil) -> AnyPublisher<P, NetworkError> {
         let endpoint: AscGenericEndpoint<P.ModelType>
         if let nextUrl = previousPageable?.nextUrl {
             endpoint = AscGenericEndpoint.url(nextUrl, type: P.ModelType.self)

--- a/Sources/ASCKit/service/ASCService.swift
+++ b/Sources/ASCKit/service/ASCService.swift
@@ -15,6 +15,10 @@ public struct ASCService {
 
     // MARK: - Generic List
 
+    #warning("""
+        return a publisher that loads all pages when limit is nil.
+        https://www.donnywals.com/recursively-execute-a-paginated-network-call-with-combine/
+    """)
     /// Generic function to get pageable models for each model of the ASC API. Automatically evaluates the previous
     /// result or fetches the first page if nil.
     public static func list<P: Pageable>(previousPageable: P?,

--- a/Sources/ASCKit/service/ASCService.swift
+++ b/Sources/ASCKit/service/ASCService.swift
@@ -7,10 +7,27 @@
 
 import Foundation
 import Engine
+import Combine
 
 public struct ASCService {
 
-    static let network = Network()
+    static let network = Network.shared
+
+    // MARK: - Generic List
+
+    /// Generic function to get pageable models for each model of the ASC API. Automatically evaluates the previous
+    /// result or fetches the first page if nil.
+    public static func list<P: Pageable>(previousPageable: P?,
+                                         filters: [Filter] = [],
+                                         limit: UInt? = nil) -> AnyPublisher<P, Network.Error> {
+        let endpoint: AscGenericEndpoint<P.ModelType>
+        if let nextUrl = previousPageable?.nextUrl {
+            endpoint = AscGenericEndpoint.url(nextUrl, type: P.ModelType.self)
+        } else {
+            endpoint = AscGenericEndpoint.list(type: P.ModelType.self, filters: filters, limit: limit)
+        }
+        return network.request(endpoint: endpoint)
+    }
 
     // MARK: - Apps
 

--- a/Sources/ASCKit/service/BuildsOperation.swift
+++ b/Sources/ASCKit/service/BuildsOperation.swift
@@ -14,8 +14,7 @@ public final class BuildsOperation: AsyncResultOperation<[Build], Network.Error>
         case expire(ids: [String])
     }
 
-    #warning("make global singletom from network")
-    let network = Network()
+    let network = Network.shared
 
     private let subcommand: SubCommand
 

--- a/Sources/ASCKit/service/BuildsOperation.swift
+++ b/Sources/ASCKit/service/BuildsOperation.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Engine
 
-public final class BuildsOperation: AsyncResultOperation<[Build], Network.Error> {
+public final class BuildsOperation: AsyncResultOperation<[Build], NetworkError> {
 
     public enum SubCommand {
         case expire(ids: [String])
@@ -43,11 +43,11 @@ public final class BuildsOperation: AsyncResultOperation<[Build], Network.Error>
 
             guard !builds.isEmpty else {
                 #warning("inform the user via PROPER error when no builds have been found")
-                finish(with: .failure(Network.Error.noData(error: nil)))
+                finish(with: .failure(NetworkError.noData(error: nil)))
                 return
             }
 
-            let results: [Result<Build, Network.Error>] = builds
+            let results: [Result<Build, NetworkError>] = builds
                 .map { AscEndpoint.expireBuild($0) }
                 .map { network.syncRequest(endpoint: $0) }
 

--- a/Sources/ASCKit/service/DeleteOperation.swift
+++ b/Sources/ASCKit/service/DeleteOperation.swift
@@ -11,7 +11,7 @@ import Engine
 /// Lists all instances of the given model
 public final class DeleteOperation<M: IdentifiableModel>: AsyncResultOperation<EmptyResponse, Network.Error> {
 
-    #warning("make global singletom from network")
+    #warning("make global singleton from network")
     let network = Network()
 
     let model: M

--- a/Sources/ASCKit/service/DeleteOperation.swift
+++ b/Sources/ASCKit/service/DeleteOperation.swift
@@ -9,7 +9,7 @@ import Foundation
 import Engine
 
 /// Lists all instances of the given model
-public final class DeleteOperation<M: IdentifiableModel>: AsyncResultOperation<EmptyResponse, Network.Error> {
+public final class DeleteOperation<M: IdentifiableModel>: AsyncResultOperation<EmptyResponse, NetworkError> {
 
     let network = Network.shared
 

--- a/Sources/ASCKit/service/DeleteOperation.swift
+++ b/Sources/ASCKit/service/DeleteOperation.swift
@@ -11,8 +11,7 @@ import Engine
 /// Lists all instances of the given model
 public final class DeleteOperation<M: IdentifiableModel>: AsyncResultOperation<EmptyResponse, Network.Error> {
 
-    #warning("make global singleton from network")
-    let network = Network()
+    let network = Network.shared
 
     let model: M
 

--- a/Sources/ASCKit/service/ListOperation.swift
+++ b/Sources/ASCKit/service/ListOperation.swift
@@ -15,8 +15,7 @@ import Engine
 /// 2. Load only the first page and succeeding ones using additional requests.
 public final class ListOperation<P: Pageable>: AsyncResultOperation<P, Network.Error> {
 
-    #warning("make global singletom from network")
-    let network = Network()
+    let network = Network.shared
 
     let filters: [Filter]
     let limit: UInt?

--- a/Sources/ASCKit/service/ListOperation.swift
+++ b/Sources/ASCKit/service/ListOperation.swift
@@ -13,7 +13,7 @@ import Engine
 /// Supports 2 modi:
 /// 1. Load all instances of the given model.
 /// 2. Load only the first page and succeeding ones using additional requests.
-public final class ListOperation<P: Pageable>: AsyncResultOperation<P, Network.Error> {
+public final class ListOperation<P: Pageable>: AsyncResultOperation<P, NetworkError> {
 
     let network = Network.shared
 

--- a/Sources/ASCKit/service/ListOperation.swift
+++ b/Sources/ASCKit/service/ListOperation.swift
@@ -8,8 +8,12 @@
 import Foundation
 import Engine
 
-/// Lists all instances of the given model
-public final class ListOperation<M: Model>: AsyncResultOperation<[M], Network.Error> {
+/// Lists instances of the given model.
+///
+/// Supports 2 modi:
+/// 1. Load all instances of the given model.
+/// 2. Load only the first page and succeeding ones using additional requests.
+public final class ListOperation<P: Pageable>: AsyncResultOperation<P, Network.Error> {
 
     #warning("make global singletom from network")
     let network = Network()
@@ -23,8 +27,8 @@ public final class ListOperation<M: Model>: AsyncResultOperation<[M], Network.Er
     }
 
     public override func main() {
-        let endpoint = AscGenericEndpoint.list(type: M.self, filters: filters, limit: limit)
-        network.request(endpoint: endpoint) { [weak self] (result: RequestResult<[M]>) in
+        let endpoint = AscGenericEndpoint.list(type: P.ModelType.self, filters: filters, limit: limit)
+        network.request(endpoint: endpoint) { [weak self] (result: RequestResult<P>) in
             self?.finish(with: result)
         }
     }

--- a/Sources/ASCKit/service/RegisterBundleIdOperation.swift
+++ b/Sources/ASCKit/service/RegisterBundleIdOperation.swift
@@ -10,7 +10,7 @@ import Engine
 
 public final class RegisterBundleIdOperation: AsyncResultOperation<BundleId, Network.Error> {
 
-    #warning("make global singletom from network")
+    #warning("make global singleton from network")
     let network = Network()
 
     let attributes: BundleId.Attributes

--- a/Sources/ASCKit/service/RegisterBundleIdOperation.swift
+++ b/Sources/ASCKit/service/RegisterBundleIdOperation.swift
@@ -10,8 +10,7 @@ import Engine
 
 public final class RegisterBundleIdOperation: AsyncResultOperation<BundleId, Network.Error> {
 
-    #warning("make global singleton from network")
-    let network = Network()
+    let network = Network.shared
 
     let attributes: BundleId.Attributes
 

--- a/Sources/ASCKit/service/RegisterBundleIdOperation.swift
+++ b/Sources/ASCKit/service/RegisterBundleIdOperation.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Engine
 
-public final class RegisterBundleIdOperation: AsyncResultOperation<BundleId, Network.Error> {
+public final class RegisterBundleIdOperation: AsyncResultOperation<BundleId, NetworkError> {
 
     let network = Network.shared
 

--- a/Sources/ASCKit/service/UrlOperation.swift
+++ b/Sources/ASCKit/service/UrlOperation.swift
@@ -1,0 +1,29 @@
+//
+//  UrlOperation.swift
+//  ASCKit
+//
+//  Created by Stefan Herold on 09.02.21.
+//
+
+import Foundation
+import Engine
+
+/// Operation for reading given urls. Query parameters like limit or filters should already be added.
+public final class UrlOperation<P: Pageable>: AsyncResultOperation<P, Network.Error> {
+
+    #warning("make global singleton from network")
+    let network = Network()
+
+    let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    public override func main() {
+        let endpoint = AscGenericEndpoint.url(url, type: P.ModelType.self)
+        network.request(endpoint: endpoint) { [weak self] (result: RequestResult<P>) in
+            self?.finish(with: result)
+        }
+    }
+}

--- a/Sources/ASCKit/service/UrlOperation.swift
+++ b/Sources/ASCKit/service/UrlOperation.swift
@@ -9,7 +9,7 @@ import Foundation
 import Engine
 
 /// Operation for reading given urls. Query parameters like limit or filters should already be added.
-public final class UrlOperation<P: Pageable>: AsyncResultOperation<P, Network.Error> {
+public final class UrlOperation<P: Pageable>: AsyncResultOperation<P, NetworkError> {
 
     let network = Network.shared
 

--- a/Sources/ASCKit/service/UrlOperation.swift
+++ b/Sources/ASCKit/service/UrlOperation.swift
@@ -11,8 +11,7 @@ import Engine
 /// Operation for reading given urls. Query parameters like limit or filters should already be added.
 public final class UrlOperation<P: Pageable>: AsyncResultOperation<P, Network.Error> {
 
-    #warning("make global singleton from network")
-    let network = Network()
+    let network = Network.shared
 
     let url: URL
 


### PR DESCRIPTION
## Support Paging for ListOperation

By default ALL results are loaded. This is the standard in e.g.
command line tools. In an app you can use the paging limit and a
special config of the operation to load each page one by one.

Remove subcommand list from BuildsOperation. Please use the good old 
ListOperation for this!

Add UrlOperation to request a simple URL ready to go with query 
parameters etc.

## Misc

- Update Package Swift version to 5.4
- Add constants for button and raster size
- Conforming Error to LoggableError
- rename Network.Error > NetworkError
