### PR TITLE
Fix Tester Deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-* Upgrade to Swift 5.6 - [@Blackjacx](https://github.com/blackjacx).
+* [#11](https://github.com/Blackjacx/ASCKit/pull/11): Fix Tester Deletion - [@Blackjacx](https://github.com/blackjacx).
 
 ## [0.1.0] - 2022-03-14Z
 * [#6](https://github.com/Blackjacx/ASCKit/pull/6): Async Await Support - [@Blackjacx](https://github.com/blackjacx).

--- a/Sources/ASCKit/ASCService.swift
+++ b/Sources/ASCKit/ASCService.swift
@@ -23,8 +23,7 @@ public struct ASCService {
 
     // MARK: - Generic List
 
-    #warning("Load all pages here when limit == nil")
-    /// Async/await function to genrically get pageable models for each model
+    /// Async/await function to generically get pageable models for each model
     /// of the ASC API. Automatically evaluates the previous result or fetches
     /// the first page if nil.
     /// - note: Suitable for both CLI tools and SwiftUI apps
@@ -41,7 +40,6 @@ public struct ASCService {
         return try await network.request(endpoint: endpoint)
     }
 
-    #warning("Load all pages here when limit == nil")
     /// Generic, throwable function to return any list of `IdentifiableModel`s.
     /// - note: Suitable for CLI tools
     public static func list<P: IdentifiableModel>(filters: [Filter] = [], limit: UInt? = nil) async throws -> [P] {

--- a/Sources/ASCKit/AscEndpoint.swift
+++ b/Sources/ASCKit/AscEndpoint.swift
@@ -84,7 +84,7 @@ extension AscGenericEndpoint: Endpoint {
     }
 
     var timeout: TimeInterval {
-        5
+        30
     }
 
     func headers() async -> [String : String]? {
@@ -187,7 +187,7 @@ extension AscEndpoint: Endpoint {
     }
 
     var timeout: TimeInterval {
-        5
+        30
     }
 
     var shouldAuthorize: Bool {

--- a/Sources/ASCKit/AscEndpoint.swift
+++ b/Sources/ASCKit/AscEndpoint.swift
@@ -295,7 +295,7 @@ extension Endpoint {
     func queryItems(from filters: [Filter], limit: UInt?) -> [URLQueryItem] {
         var items: [URLQueryItem] = []
         items += filters.map { URLQueryItem(name: "filter[\($0.key)]", value: $0.value) }
-        items += [URLQueryItem(name: "limit", value: "\(limit ?? Constants.maxPageSize)")]
+        items += [URLQueryItem(name: "limit", value: "\(Constants.defaultLimit(limit))")]
         return items
     }
 }

--- a/Sources/ASCKit/AscEndpoint.swift
+++ b/Sources/ASCKit/AscEndpoint.swift
@@ -18,9 +18,10 @@ enum AscGenericEndpoint<M: Model> {
 }
 
 enum AscEndpoint {
-    case read(url: URL, filters: [Filter], limit: UInt)
+    case read(url: URL, filters: [Filter], limit: UInt?)
 
     case listAppStoreVersions(appId: String, filters: [Filter], limit: UInt?)
+    case listAllBetaGroupsForTester(id: String, filters: [Filter], limit: UInt?)
 
     case inviteBetaTester(testerId: String, appId: String)
     case addBetaTester(email: String, firstName: String, lastName: String, groupId: String)
@@ -153,6 +154,7 @@ extension AscEndpoint: Endpoint {
         case .read(let url, _, _): return url.path
         case .listAppStoreVersions(let appId, _, _): return "/\(apiVersion)/apps/\(appId)/appStoreVersions"
 
+        case .listAllBetaGroupsForTester(let id, _, _): return "/\(apiVersion)/betaTesters/\(id)/betaGroups"
         case .inviteBetaTester: return "/\(apiVersion)/betaTesterInvitations"
         case .addBetaTester: return "/\(apiVersion)/betaTesters"
 
@@ -164,10 +166,9 @@ extension AscEndpoint: Endpoint {
 
     var queryItems: [URLQueryItem] {
         switch self {
-        case let .read(_, filters, limit):
-            return queryItems(from: filters, limit: limit)
-
-        case let .listAppStoreVersions(_, filters, limit):
+        case .read(_, let filters, let limit),
+                .listAppStoreVersions(_, let filters, let limit),
+                .listAllBetaGroupsForTester(_, let filters, let limit):
             return queryItems(from: filters, limit: limit)
 
         case .inviteBetaTester, .addBetaTester, .registerBundleId, .expireBuild:
@@ -177,7 +178,7 @@ extension AscEndpoint: Endpoint {
 
     var method: HTTPMethod {
         switch self {
-        case .read, .listAppStoreVersions:
+        case .read, .listAppStoreVersions, .listAllBetaGroupsForTester:
             return .get
         case .addBetaTester, .inviteBetaTester, .registerBundleId:
             return .post
@@ -212,7 +213,7 @@ extension AscEndpoint: Endpoint {
 
     var parameters: [String : Any]? {
         switch self {
-        case .read, .listAppStoreVersions:
+        case .read, .listAppStoreVersions, .listAllBetaGroupsForTester:
             return nil
         case let .addBetaTester(email, firstName, lastName, groupId):
             return [

--- a/Sources/ASCKit/Constants.swift
+++ b/Sources/ASCKit/Constants.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public enum Constants {
-    public static let defaultPageSize: UInt = 50
+    public static let defaultPageSize: UInt = 200
     public static let maxPageSize: UInt = 200
 }
 

--- a/Sources/ASCKit/Constants.swift
+++ b/Sources/ASCKit/Constants.swift
@@ -8,8 +8,16 @@
 import Foundation
 
 public enum Constants {
+    /// The max allowed page size by Apple is `200`
     public static let defaultPageSize: UInt = 200
-    public static let maxPageSize: UInt = 200
+    public static let maxAllowedPageSize: UInt = 200
+
+    public static func defaultLimit(_ givenLimit: UInt?) -> UInt {
+        guard let givenLimit else {
+            return defaultPageSize
+        }
+        return min(givenLimit, maxAllowedPageSize)
+    }
 }
 
 #if canImport(UIKit)

--- a/Sources/ASCKit/Filter.swift
+++ b/Sources/ASCKit/Filter.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Filter {
+public struct Filter: CustomStringConvertible {
 
     public let key: AnyHashable
     public let value: String
@@ -15,6 +15,12 @@ public struct Filter {
     public init(key: AnyHashable, value: String) {
         self.key = key
         self.value = value
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        "Filter(Key: \(key), Value: \(value))"
     }
 }
 

--- a/Sources/ASCKit/Model.swift
+++ b/Sources/ASCKit/Model.swift
@@ -14,8 +14,8 @@ public protocol Pageable: Model {
     associatedtype ModelType: Model
 
     var data: [ModelType] { get }
-    var totalCount: Int { get }
-    var limit: Int { get }
+    var totalCount: UInt { get }
+    var limit: UInt { get }
     var nextUrl: URL? { get }
 }
 

--- a/Sources/ASCKit/PagedItemLoader.swift
+++ b/Sources/ASCKit/PagedItemLoader.swift
@@ -21,9 +21,12 @@ public final class PagedItemLoader<Item: IdentifiableModel>: ObservableObject {
     private var canLoadMorePages = true
 
 
-    /// Initializer with the possibility to specify a pagaing limit.
-    /// - Parameter limit: The maximum size of one page of items. Specify `nil` if you want to load all items at once.
-    public init(filters: [Filter] = [], limit: UInt? = Constants.defaultPageSize) {
+    /// Initializer with the possibility to specify a paging limit.
+    /// - Parameters
+    ///   - limit: The maximum size of one page of items AND the amount of
+    ///   items to load. Specify `nil` if you want to load all pages. In that
+    ///   case the page size will be the Apple default.
+    public init(filters: [Filter] = [], limit: UInt?) {
         self.filters = filters
         self.limit = limit
     }
@@ -51,6 +54,8 @@ public final class PagedItemLoader<Item: IdentifiableModel>: ObservableObject {
 
         items += pageableResult.data
         pageableItems = pageableResult
-        canLoadMorePages = pageableResult.totalCount > items.count
+        canLoadMorePages = pageableResult.totalCount > items.count && limit == nil
+
+        try await loadMoreContent()
     }
 }

--- a/Sources/ASCKit/models/PageableModel.swift
+++ b/Sources/ASCKit/models/PageableModel.swift
@@ -12,8 +12,8 @@ public struct PageableModel<M: Model>: Pageable {
     public typealias ModelType = M
     public var data: [ModelType]
 
-    public var totalCount: Int { meta.paging.total }
-    public var limit: Int { meta.paging.limit }
+    public var totalCount: UInt { meta.paging.total }
+    public var limit: UInt { meta.paging.limit }
     public var nextUrl: URL? { links.next }
 
     var meta: PagingInformation
@@ -39,9 +39,9 @@ struct PagingInformation: Model {
 
     struct Paging: Model {
         /// (Required) The total number of resources matching your request.
-        var total: Int
+        var total: UInt
         /// (Required) The maximum number of resources to return per page, from 0 to 200.
-        var limit: Int
+        var limit: UInt
     }
 
     /// The paging information details.


### PR DESCRIPTION
# Changes

## Fix beta tester deletion
Now all testers are deleted that are found (before only the first one
was deleted). An additional check is implemented which determines if
the user is still in any VALID beta groups. If a user is only in
INVALID beta groups he is treated as deleted. See comment on
`allValidTesterGroups`.

Specifying filters is way more flexible since we can now search beta
testers by email, firstName, lastName, … in one command call. 🚨 Please
use this power with caution though! Specifying just a first name will
delete all testers that share the same first name.

The for loop over all filters (previously over all emails) has been
moved from Assist to ASCKit to keep the command implementation small.

No error is thrown anymore when no testers have been found. The testers
are just not added to `allDeletedTesters` result anymore.

## Fixed behavior of limit parameter `-l`

```
Limit = nil
Page size: default
Pages fetched: ALL

Limit = 0
Page size: 0
Pages fetched: 1

Limit = 1
Page size: 1
Pages fetched: 1

Limit > maxAllowedPageSize
Page size: defaultPageSize
Pages fetched: 1
```

## Conform `Filter` to `CustomStringConvertible`

## Increased timeout interval to 30s
- Before we often ran into timeouts.
- Updated for `AscEndpoint` and `AscGenericEndpoint`

## Increase default page size to 200
This is the max allowed value by Apple

## Implement list beta groups for specific tester
We can now list all beta groups for a list of beta testers.